### PR TITLE
Make sure the symlink to the running version is created after the file download

### DIFF
--- a/manifests/install/download.pp
+++ b/manifests/install/download.pp
@@ -49,6 +49,7 @@ class serf::install::download (
     }
 
     file { 'serf':
+        ensure  => link,
         path    => "${install_path}/serf",
         target  => "${install_path}/serf-${version}",
         require => File["serf-${version}"],


### PR DESCRIPTION
Hey!  Great work on this module, wasn't happy with the ones on the forge already so I had been thinking of writing one, but this one's functionality is exactly what I want.

Ran into one issue during setup, the `${install_path}/serf-${version}` file was getting in place but `${install_path}/serf` was getting created as an empty file instead of a link - a second run was needed to converge and fix the link.  This change adds `ensure => link` and `require => File["serf-${version}"],` to the symlink resource, which resolve the issue.

Thanks!
