### PR TITLE
Add support for the 'discover' option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@ class serf (
     $tags           = undef,
     $start_join     = undef,
     $profile        = undef,
+    $discover       = undef,
     $rpc_address    = undef,
     $rpc_port       = undef,
     $rpc_auth       = undef,
@@ -26,7 +27,7 @@ class serf (
 ) {
 
     class { $install_class: }
-    
+
     anchor { 'serf::install': }
 
     File {

--- a/templates/serf.conf.erb
+++ b/templates/serf.conf.erb
@@ -11,6 +11,7 @@ config_file['event_handlers'] = @event_handlers unless @event_handlers.empty?
 config_file['tags'] = @tags unless @tags.empty?
 config_file['start_join'] = @start_join unless @start_join.empty?
 config_file['profile'] = @profile unless @profile.to_s.empty?
+config_file['discover'] = @discover unless @discover.empty?
 config_file['rpc_addr'] = "#{@rpc_address}:#{@rpc_port}" unless @rpc_address.to_s.empty?
 config_file['rpc_auth'] = @rpc_auth unless @rpc_auth.to_s.empty?
 config_file['log_level'] = @log_level if @log_level


### PR DESCRIPTION
This change adds support for the 'discover' option, which is a cluster
name that Serf will use to automatically detect peers using mDNS.