### PR TITLE
Support Redhat/CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ three classes which may be used for this purpose, `serf::service::initscript`,
 An empty value of `''` may be used if no additional configuration is necessary
 in order to satisfy the `service` resource requirement (for example, when using
 `serf::install::package` to install a package that contains appropriate service
-configuration). Default: on Debian-based platforms:`serf::service::initscript`,
+configuration). Default: on Debian-based, and Redhat family 6 platforms:`serf::service::initscript`,
 on Ubuntu: `serf::service::upstart`, on Redhat family 7 : `serf::service::systemd`
 
 #### `service_enable`
@@ -280,6 +280,7 @@ This module is known to work on:
 * Ubuntu 12.04 Precise Pangolin
 * Debian 7.x wheezy
 * Redhat/CentOS 7
+* Redhat/ CentOS 6
 * Raspbian
 
 Pull requests enabling use of the module on additional platforms are welcome.

--- a/README.md
+++ b/README.md
@@ -158,13 +158,21 @@ The name of the Puppet class that will be included into the catalog in order to
 configure Serf as a service. Any arbitrary Puppet class may fill this role,
 however the supplied class must leave the system in a state such that Puppet's
 `service` resource recognises `serf` as valid and extant. The module includes
-two classes which may be used for this purpose, `serf::service::initscript` and
-`serf::service::upstart`, which are documented separately. An empty value of
-`''` may be used if no additional configuration is necessary in order to
-satisfy the `service` resource requirement (for example, when using
+three classes which may be used for this purpose, `serf::service::initscript`,
+`serf::service::systemd` and `serf::service::upstart`, which are documented separately.
+An empty value of `''` may be used if no additional configuration is necessary
+in order to satisfy the `service` resource requirement (for example, when using
 `serf::install::package` to install a package that contains appropriate service
-configuration). Default: on Debian-based platforms:
-`serf::service::initscript`, on Ubuntu: `serf::service::upstart`
+configuration). Default: on Debian-based platforms:`serf::service::initscript`,
+on Ubuntu: `serf::service::upstart`, on Redhat family 7 : `serf::service::systemd`
+
+#### `service_enable`
+
+Serf service status. Default: `'running'`
+
+#### `service_enable`
+
+Serf service state at boot. Default: `'true'`
 
 #### `install_path`
 
@@ -229,6 +237,23 @@ Default: `${::serf::install_path}`
 The path where the `serf.conf` configuration file is located. This parameter
 need not be set. Default: `${::serf::config_dir}`
 
+## Class `serf::service::systemd`
+
+This class configures Serf as a service by installing an systemd-style
+startup script.
+
+### Parameters
+
+#### `install_path` (Private)
+
+The path where the `serf` binary is located. This parameter need not be set.
+Default: `${::serf::install_path}`
+
+#### `config_dir` (Private)
+
+The path where the `serf.conf` configuration file is located. This parameter
+need not be set. Default: `${::serf::config_dir}`
+
 ## Class `serf::service::upstart`
 
 This class configures Serf as a service by installing an upstart configuration
@@ -254,6 +279,7 @@ This module is known to work on:
 * Ubuntu 14.04 Trusty Tahr
 * Ubuntu 12.04 Precise Pangolin
 * Debian 7.x wheezy
+* Redhat/CentOS 7
 * Raspbian
 
 Pull requests enabling use of the module on additional platforms are welcome.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,11 +23,14 @@ class serf (
     $service_class  = undef,
     $service_ensure = 'running',
     $service_enable = 'true',
-    $service_provider = undef,
 
     $install_path   = undef,
 ) {
 
+    case $service_class {
+      '::serf::service::upstart': { $service_provider = 'upstart' }
+      default: { $service_provider = undef }
+    }
     class { $install_class: }
 
     anchor { 'serf::install': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,12 +21,14 @@ class serf (
     $config_group   = undef,
 
     $service_class  = undef,
+    $service_ensure = 'running',
+    $service_enable = 'true',
 
     $install_path   = undef,
 ) {
 
     class { $install_class: }
-    
+
     anchor { 'serf::install': }
 
     File {
@@ -59,8 +61,8 @@ class serf (
     anchor { 'serf::config': }
 
     service { 'serf':
-        ensure  => running,
-        enable  => true,
+        ensure  => $service_ensure,
+        enable  => $service_enable,
         require => Anchor['serf::install', 'serf::config']
     }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@ class serf (
     $service_class  = undef,
     $service_ensure = 'running',
     $service_enable = 'true',
+    $service_provider = undef,
 
     $install_path   = undef,
 ) {
@@ -61,8 +62,9 @@ class serf (
     anchor { 'serf::config': }
 
     service { 'serf':
-        ensure  => $service_ensure,
-        enable  => $service_enable,
-        require => Anchor['serf::install', 'serf::config']
+        ensure   => $service_ensure,
+        enable   => $service_enable,
+        provider => $service_provider,
+        require  => Anchor['serf::install', 'serf::config']
     }
 }

--- a/manifests/service/initscript.pp
+++ b/manifests/service/initscript.pp
@@ -3,11 +3,15 @@ class serf::service::initscript (
     $install_path = $::serf::install_path,
     $config_dir   = $::serf::config_dir,
 ) {
+  case $::osfamily {
+    'Debian': { $template = 'serf/initscript.erb' }
+    'RedHat': { $template = 'serf/sysvinit.erb' }
+  }
     file { '/etc/init.d/serf':
         owner   => 'root',
         group   => 'root',
         mode    => '0755',
-        content => template('serf/initscript.erb'),
+        content => template($template),
         require => Anchor['serf::install'],
         before  => Anchor['serf::config'],
         notify  => Service['serf'],

--- a/manifests/service/systemd.pp
+++ b/manifests/service/systemd.pp
@@ -1,0 +1,15 @@
+# ex: syntax=puppet sw=4 ts=4 si et
+class serf::service::systemd (
+    $install_path = $::serf::install_path,
+    $config_dir   = $::serf::config_dir,
+) {
+    file { '/usr/lib/systemd/system/serf.service':
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        content => template('serf/systemd.service.erb'),
+        require => Anchor['serf::install'],
+        before  => Anchor['serf::config'],
+        notify  => Service['serf'],
+    }
+}

--- a/spec/classes/serf_spec.rb
+++ b/spec/classes/serf_spec.rb
@@ -33,4 +33,13 @@ describe 'serf' do
 
     it { should contain_class('serf::service::upstart') }
   end
+
+  context 'using systemd service' do
+    let(:facts) { {
+      :osfamily => 'RedHat',
+      :operatingsystemmajrelease => '7'
+    } }
+
+    it { should contain_class('serf::service::systemd') }
+  end
 end

--- a/templates/systemd.service.erb
+++ b/templates/systemd.service.erb
@@ -1,0 +1,21 @@
+## managed by Puppet ##
+# Serf Agent (systemd service unit)
+[Unit]
+Description=Serf Agent
+After=syslog.target
+After=network.target
+
+[Service]
+Type=simple
+# Ensure the configuration directory exists.
+ExecStartPre=/usr/bin/install -d -g root -o root <%= @config_dir %>
+ExecStart=<%= @install_path %>/serf agent -config-dir=<%= @config_dir %>
+# Use SIGINT instead of SIGTERM so serf can depart the cluster.
+KillSignal=SIGINT
+# Restart on success, failure, and any emitted signals like HUP.
+Restart=always
+# Wait ten seconds before respawn attempts.
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/sysvinit.erb
+++ b/templates/sysvinit.erb
@@ -1,0 +1,76 @@
+#!/bin/sh
+#
+# serf - this script starts and stops the serf service daemon
+#
+# chkconfig: 345 99 1
+# description:  serf
+# processname: serf
+# pidfile:     /var/run/serf.pid
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+prog=serf
+cmd="<%= @install_path %>/${prog} agent"
+pidfile="/var/run/${prog}.pid"
+lockfile="/var/lock/subsys/${prog}"
+
+SERF_CONFIG_DIR="<%= @config_dir %>"
+SERF_LOG_FILE="/var/log/serf.log"
+
+[[ -f /etc/sysconfig/serf ]] && . /etc/sysconfig/serf
+
+[[ -d $SERF_CONFIG_DIR ]] || mkdir -p $SERF_CONFIG_DIR
+
+start() {
+    echo -n $"Starting $prog: "
+    daemon --pidfile=$pidfile "${cmd} -config-dir=$SERF_CONFIG_DIR >> $SERF_LOG_FILE &"
+    retval=$?
+    ps -ef | grep -F "${cmd}" | grep -v 'grep' | awk '{print $2}' > ${pidfile}
+    [ $retval -eq 0 ] && touch $lockfile && success
+    echo
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping $prog: "
+    killproc -p $pidfile $prog
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+rh_status() {
+    status $prog
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+restart() {
+    stop
+    start
+}
+
+case "$1" in
+start)
+    rh_status_q && exit 0
+    $1
+    ;;
+stop)
+    #rh_status_q && exit 0
+    $1
+    ;;
+restart)
+    $1
+    ;;
+status|status_q)
+    rh_$1
+    ;;
+*)
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit 2
+esac
+exit 0


### PR DESCRIPTION
 [x] add support for systemd service
 [x] add serf::service::systemd and corresponding template
 [x] parametrize status, state of serf service
 [x] update spec/classes/serf_spec.rb with systemd context
 [x] add support for redhat6 init script
 [x] support choosing service provider
 [x] set service provider to upstart if upstart service is choosen in non-upstart default systems
 [x] update README.md to add Redhat/CentOS 6 as supported systems and RedHat/CentOS 7